### PR TITLE
add dewezet and cz

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Works on this websites:
 - https://www.paz-online.de
 - https://www.sn-online.de
 - https://www.rnd.de
+- https://www.dewezet.de
+- https://www.cz.de
 
 Installation
 

--- a/RNDplus4free.user.js
+++ b/RNDplus4free.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     RNDplus4free
 // @description Laden des Artikel-Textes aus dem JSON im Quelltext
-// @version  0.5.10a
+// @version  0.5.11a
 // @match https://*.haz.de/*.html*
 // @match https://*.neuepresse.de/*.html*
 // @match https://*.sn-online.de/*.html*
@@ -13,8 +13,9 @@
 // @match https://*.maz-online.de/*.html*
 // @match https://*.ostsee-zeitung.de/*.html*
 // @match https://*.paz-online.de/*.html*
-// @match https://*.sn-online.de/*.html*
 // @match https://*.rnd.de/*.html*
+// @match https://*.dewezet.de/*.html*
+// @match https://*.cz.de/*.html*
 // ==/UserScript==
 
 // Redirect from AMP to normal site


### PR DESCRIPTION
Funktioniert auch für die Deister- und Weserzeitung (dewezet)
Außerdem habe ich die Cellesche Zeitung wieder hinzugefügt. Die wurde anscheinend nach dem Update auf 0.5.1 rausgenommen, aber funktioniert aktuell.

Der Eintrag für `sn-online.de` war doppelt enthalten.