### PR TITLE
fix: Remove ESlint error for unknown global variable 'Fusion' and fix too narrow first paragraph 

### DIFF
--- a/RNDplus4free.user.js
+++ b/RNDplus4free.user.js
@@ -19,6 +19,8 @@
 // @match https://*.szlz.de/*.html*
 // ==/UserScript==
 
+/* global Fusion:readonly */
+
 // Redirect from AMP to normal site
 function redirectWithoutValidAmp(currentUrl) {
     let newUrl = currentUrl.replace("outputType=valid_amp", "");

--- a/RNDplus4free.user.js
+++ b/RNDplus4free.user.js
@@ -132,4 +132,7 @@ setTimeout(function() {
     styleElement.sheet.insertRule('.article-text { color: #fff; mix-blend-mode: difference; margin: 0px; padding-bottom: 8px; padding-top: 8px; font-family: "Source Serif Pro", Palatino, "Droid Serif", serif; font-size: 17px; font-weight: 600; letter-spacing: 0px; line-height: 26px; }', 0);
     styleElement.sheet.insertRule('.article-header { color: #fff; mix-blend-mode: difference; font-family: "DIN Next LT Pro", Arial, Roboto, sans-serif; font-weight: 700; letter-spacing: -0.25px; font-size: 24px; line-height: 30px; }', 0);
     styleElement.sheet.insertRule('.ArticleHeadstyled__ArticleSubHeadline-sc-tdzyy5-8 { height: 100% }', 0);
+
+    // Fix too narrow first paragraph
+    document.querySelector('.paywalledContent > p').setAttribute('style', 'height: 100%');
 }, 2000);


### PR DESCRIPTION
The first paragraph of a hidden article is limited to 50 pixels in height. In the previous version of the script, this limit is not removed even after the following paragraphs have been reloaded, so that the rest of the first paragraph is covered by the newly loaded paragraph.

![image](https://github.com/user-attachments/assets/6216ab3e-5a31-406f-9879-6ac17bffa48c)

With this correction, the height limit is removed, and all paragraphs can be read correctly again.


In addition, a small comment has been added to ensure that the JavaScript linter (e.g. within Tampermonkey) no longer complains about the global variable `Fusion`.

![image](https://github.com/user-attachments/assets/c192d445-0383-4f4e-bf73-59e6efc16ba4)

